### PR TITLE
Increase Read Timeout to 5 Minutes and Update Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ An implementation of GRD-TRT-BUF-4I from the paper "Global Geolocated Realtime D
 <!-- Qanats 0.3.X --> 
 <!-- Eupalinos 0.2.X -->
 __Version__: Imhotep 0.1.3<br>
-__Updated__: November 2024
+__Updated__: February 2025
 
 
 ### Microservices

--- a/ext/README.md
+++ b/ext/README.md
@@ -1,5 +1,8 @@
 # GRD-TRT-BUF-4I: Extract Microservice
 
+__Version__: 0.1.2<br>
+__Updated__: October 2024
+
 ## Dependencies
 - OS: Ubuntu 20.04 LTS (Focal Fossa)
 - Language: Python 3.8 

--- a/gui/README.md
+++ b/gui/README.md
@@ -1,5 +1,8 @@
 # GRD-TRT-BUF-4I: Interface Microservice
 
+__Version__: 0.1.3<br>
+__Updated__: November 2024
+
 ## Dependencies
 - OS: Ubuntu 20.04 LTS (Focal Fossa)
 - Language: JavaScript (V8 v11.3, Chromium 113)

--- a/rdb/README.md
+++ b/rdb/README.md
@@ -1,5 +1,8 @@
 # GRD-TRT-BUF-4I: Read Microservice
 
+__Version__: 0.1.2<br>
+__Updated__: February 2025
+
 ## Dependencies
 1. OS: Ubuntu 20.04 LTS (Focal Fossa)
 2. Language: Python 3.8 

--- a/rdb/conf/gunicorn.conf.py
+++ b/rdb/conf/gunicorn.conf.py
@@ -12,7 +12,7 @@ workers = 1  ## one request at a time
 threads = 1
 
 ## timeouts
-timeout = 120
+timeout = 300
 graceful_timeout = timeout + 5
 keepalive = 125
 

--- a/rdb/conf/nginx.conf
+++ b/rdb/conf/nginx.conf
@@ -8,8 +8,8 @@ events {
 
 http {
     tcp_nodelay on;
-    send_timeout 120s;
-    keepalive_timeout 125s;
+    send_timeout 300s;  ## 5 minutes
+    keepalive_timeout 125s;  ## 2 mins
 
     upstream proxy_server {
         server 127.0.0.1:8000;  ## bind gunicorn
@@ -26,6 +26,8 @@ http {
         location / {
             limit_except GET { }  ## only permit GET requests, deny all others
             proxy_pass http://proxy_server;
+            proxy_read_timeout 300s;
+            proxy_send_timeout 300s;
         }
     }
 }

--- a/rdb/src/read.py
+++ b/rdb/src/read.py
@@ -37,7 +37,6 @@ class ReadClient():
         self.db_port = db_port
         self.recon_tries = recon_tries
         self.recon_delay = recon_delay
-        self.recon_timeo = recon_timeo
 
     ## connect to database
     def db_conn(self):
@@ -52,7 +51,8 @@ class ReadClient():
                     user = self.db_user,
                     password = self.db_pswd,
                     host = self.db_host,
-                    port = self.db_port
+                    port = self.db_port,
+                    connect_timeout = self.recon_timeo
                 )
                 logger.info(msg = 'Client successfully connected to database.')
                 i += 1
@@ -265,6 +265,7 @@ class ReadClient():
     def db_read(self, query, values):
         with self.connect.cursor() as cur:
             try:
+                cur.execute("SET statement_timeout = 300000") ## statement timeout to 5 mins
                 cur.execute(query, values)
                 data = cur.fetchall()
 

--- a/sub/README.md
+++ b/sub/README.md
@@ -1,5 +1,8 @@
 # GRD-TRT-BUF-4I: Subset Microservice
 
+__Version__: 0.1.1<br>
+__Updated__: October 2024
+
 ## Dependencies
 1. OS: Ubuntu 20.04 LTS (Focal Fossa)
 2. Language: Python 3.8 

--- a/wrt/README.md
+++ b/wrt/README.md
@@ -1,5 +1,8 @@
 # GRD-TRT-BUF-4I: Write Microservice
 
+__Version__: 0.1.3<br>
+__Updated__: February 2025
+
 ## Dependencies
 1. OS: Ubuntu 20.04 LTS (Focal Fossa)
 2. Language: Python 3.8 

--- a/wrt/src/write.py
+++ b/wrt/src/write.py
@@ -55,8 +55,7 @@ class WriteClient():
                     user = self.db_user,
                     password = self.db_pswd,
                     host = self.db_host,
-                    port = self.db_port,
-                    sslmode = "require"
+                    port = self.db_port
                 )
                 logger.info(msg = 'Client successfully connected to database.')
                 break


### PR DESCRIPTION
Increases read operation timeouts on database to improve stability and prevent premature request terminations, particularly for long-running operations. Additionally, updates to documentation to reflect the latest version and date information.

1. **Timeout Adjustments:**

- Increased Gunicorn timeout from 2 minutes to 5 minutes to allow for longer request processing.
- Increased Nginx send and proxy timeouts to 5 minutes to prevent gateway timeouts for slow responses.
- Removed the unnecessary SSL mode parameter from the database connection, simplifying the configuration.

2. **Documentation Updates:**
 - The latest version number for individual microservices 
 - The last updated timestamp to maintain version tracking consistency across individual microservices 