### PR TITLE
Update Endpoints for Vancouver and Tampa

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ An implementation of GRD-TRT-BUF-4I from the paper "Global Geolocated Realtime D
 <!-- Qanats 0.3.X --> 
 <!-- Eupalinos 0.2.X -->
 __Version__: Imhotep 0.1.3<br>
-__Updated__: February 2025
+__Updated__: May 2025
 
 
 ### Microservices

--- a/ext/README.md
+++ b/ext/README.md
@@ -1,7 +1,7 @@
 # GRD-TRT-BUF-4I: Extract Microservice
 
-__Version__: 0.1.2<br>
-__Updated__: October 2024
+__Version__: 0.1.3<br>
+__Updated__: May 2025
 
 ## Dependencies
 - OS: Ubuntu 20.04 LTS (Focal Fossa)

--- a/ext/conf/feed/ca-west.ini
+++ b/ext/conf/feed/ca-west.ini
@@ -1,5 +1,5 @@
 [api]
-API_END_YVR=https://gtfs.translink.ca/v2/gtfsposition
+API_END_YVR=https://gtfsapi.translink.ca/v3/gtfsrealtime
 API_END_YYC=https://data.calgary.ca/download/am7c-qe3u/
 API_END_YEG=http://gtfs.edmonton.ca/TMGTFSRealTimeWebService/Vehicle/VehiclePositions.pb
 API_END_YXE=https://apps2.saskatoon.ca/app/data/Vehicle/VehiclePositions.pb

--- a/ext/conf/feed/us-suth.ini
+++ b/ext/conf/feed/us-suth.ini
@@ -1,6 +1,6 @@
 [api]
 API_END_ATL=https://gtfs-rt.itsmarta.com/TMGTFSRealTimeWebService/vehicle/vehiclepositions.pb
 API_END_MIA=https://api.goswift.ly/real-time/miami/gtfs-rt-vehicle-positions
-API_END_TPA=http://api.tampa.onebusaway.org:8088/vehicle-positions
+API_END_TPA=https://api.goswift.ly/real-time/tampa/gtfs-rt-vehicle-positions
 API_END_SDF=http://gtfsrealtime.ridetarc.org/realtime/Vehicle/VehiclePositions.pb
 API_END_BNA=http://transitdata.nashvillemta.org/TMGTFSRealTimeWebService/vehicle/vehiclepositions.pb

--- a/ext/src/extract.py
+++ b/ext/src/extract.py
@@ -239,7 +239,7 @@ class ExtractClient():
                         )
                     )
                 ## los angeles, miami
-                elif i in ['API_END_LAX', 'API_END_MIA']:
+                elif i in ['API_END_LAX', 'API_END_MIA', 'API_END_TPA']:
                     headers['Authorization'] = self.keys['API_KEY_LBM']
                     connection.append(
                         fetch(


### PR DESCRIPTION
Updates the GTFS real-time endpoints for Vancouver and Tampa to reflect the latest data feed URLs. Adds initial support for the new Tampa API structure. Documentation has been updated to reflect a new release version and a revised release date of May 2025.